### PR TITLE
Introduce tags, apps have tags

### DIFF
--- a/internal/provider/appids.go
+++ b/internal/provider/appids.go
@@ -23,8 +23,11 @@ import (
 )
 
 const (
-	appIdsAppIdsKey = "app_ids"
-	appIdsIdValue   = "splunkconfig_app_ids"
+	appIdsTagKey       = "require_tag"
+	appIdsTagNameKey   = "name"
+	appIdsTagsValueKey = "values"
+	appIdsAppIdsKey    = "app_ids"
+	appIdsIdValue      = "splunkconfig_app_ids"
 )
 
 func resourceAppIds() *schema.Resource {
@@ -32,6 +35,28 @@ func resourceAppIds() *schema.Resource {
 		Description: "Return App IDs from the Splunk Configuration",
 		ReadContext: resourceAppIdsRead,
 		Schema: map[string]*schema.Schema{
+			appIdsTagKey: {
+				Description: "Tags to require for returned App IDs",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						appIdsTagNameKey: {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Name of the tag to require",
+						},
+						appIdsTagsValueKey: {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: "Values of the tag to require",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 			appIdsAppIdsKey: {
 				Description: "List of App IDs in the Splunk Configuration",
 				Type:        schema.TypeList,
@@ -47,12 +72,34 @@ func resourceAppIdsRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 	d.SetId(appIdsIdValue)
 
+	// nested schemas are "fun".
+	// we have to iterate through each piece as a list or map of interfaces, and type assert
+	// to the true type at each layer that is nested.
+	// this block does that, converting the []interface{} that the SDK gives us into a Tags object.
+	// start with a list of interfaces, each of which is a tag block
+	tagInterfaces := d.Get(appIdsTagKey).([]interface{})
+	tags := make(config.Tags, len(tagInterfaces))
+	for tagNumber, tagInterface := range tagInterfaces {
+		// type assert the item into a map (with keys of "name" and "values")
+		tagMap := tagInterface.(map[string]interface{})
+		tagName := tagMap[appIdsTagNameKey].(string)
+		// when fetching the "values" key, we'll get a list of interfaces
+		tagValueInterfaces := tagMap[appIdsTagsValueKey].([]interface{})
+		tagValues := make([]string, len(tagValueInterfaces))
+		for tagValueNumber, tagValueInterface := range tagValueInterfaces {
+			// type assert the value interface into a string
+			tagValues[tagValueNumber] = tagValueInterface.(string)
+		}
+		// add a tag with the determiend name/values to our real Tags object
+		tags[tagNumber] = config.Tag{Name: tagName, Values: tagValues}
+	}
+
 	apps, err := suite.ExtrapolatedApps()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set(appIdsAppIdsKey, apps.AppIDs()); err != nil {
+	if err := d.Set(appIdsAppIdsKey, apps.AppIDsSatisfyingTags(tags)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/appids_test.go
+++ b/internal/provider/appids_test.go
@@ -26,10 +26,15 @@ func TestAccResourceAppIds(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAppIdsConfig,
-				Check: testCheckResourceAttrList("data.splunkconfig_app_ids.foo", "app_ids", []string{
-					"app_a",
-					"app_b",
-				}),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceAttrList("data.splunkconfig_app_ids.all", "app_ids", []string{
+						"app_a",
+						"app_b",
+					}),
+					testCheckResourceAttrList("data.splunkconfig_app_ids.filtered", "app_ids", []string{
+						"app_a",
+					}),
+				),
 			},
 		},
 	})
@@ -41,10 +46,20 @@ provider "splunkconfig" {
 apps:
   - id: app_a
     name: App A
+    tags:
+      - name: env
+        values: [prod]
   - id: app_b
     name: App B
 EOT
 }
 
-data "splunkconfig_app_ids" "foo" {}
+data "splunkconfig_app_ids" "all" {}
+
+data "splunkconfig_app_ids" "filtered" {
+	require_tag {
+		name   = "env"
+		values = ["prod"]
+	}
+}
 `

--- a/internal/splunkconfig/config/app.go
+++ b/internal/splunkconfig/config/app.go
@@ -36,6 +36,7 @@ type App struct {
 	RolesPlaceholder   RolesPlaceholder   `yaml:"roles"`
 	LookupsPlaceholder LookupsPlaceholder `yaml:"lookups"`
 	ACL                ACL
+	Tags               Tags
 }
 
 // validate returns an error if App is invalid.  It is invalid if:

--- a/internal/splunkconfig/config/apps.go
+++ b/internal/splunkconfig/config/apps.go
@@ -58,10 +58,18 @@ func (apps Apps) WithID(name string) (found App, ok bool) {
 
 // AppIDs returns a list of AppID values for each App in the list.
 func (apps Apps) AppIDs() []AppID {
-	appIDs := make([]AppID, len(apps))
+	return apps.AppIDsSatisfyingTags(Tags{})
+}
 
-	for i, app := range apps {
-		appIDs[i] = app.ID
+// AppIDsWithTags returns a list of AppID values for each App that contains the
+// given Tags.
+func (apps Apps) AppIDsSatisfyingTags(checkTags Tags) []AppID {
+	appIDs := make([]AppID, 0, len(apps))
+
+	for _, app := range apps {
+		if app.Tags.satisfiesTags(checkTags) {
+			appIDs = append(appIDs, app.ID)
+		}
 	}
 
 	return appIDs

--- a/internal/splunkconfig/config/tag.go
+++ b/internal/splunkconfig/config/tag.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// Tag contains the list of values for a given tag name.
+type Tag struct {
+	Name   string
+	Values []string
+}
+
+// hasValue returns true if the given value exists in the Tag.
+func (t Tag) hasValue(checkValue string) bool {
+	for _, value := range t.Values {
+		if value == checkValue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasValues returns true if all of the given values exist in the Tag.
+func (t Tag) hasValues(checkValues []string) bool {
+	for _, checkValue := range checkValues {
+		if !t.hasValue(checkValue) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// satisfiesTag returns true if Tag has the same name and at least all of the Values
+// as another Tag.
+func (t Tag) satisfiesTag(checkTag Tag) bool {
+	if t.Name != checkTag.Name {
+		return false
+	}
+
+	if !t.hasValues(checkTag.Values) {
+		return false
+	}
+
+	return true
+}

--- a/internal/splunkconfig/config/tag_test.go
+++ b/internal/splunkconfig/config/tag_test.go
@@ -1,0 +1,108 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTag_hasValue(t *testing.T) {
+	tests := []struct {
+		inputTag   Tag
+		inputValue string
+		want       bool
+	}{
+		{
+			Tag{Values: []string{"present"}},
+			"present",
+			true,
+		},
+		{
+			Tag{Values: []string{"present"}},
+			"missing",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.inputTag.hasValue(test.inputValue)
+		message := fmt.Sprintf("%#v.hasValue(%q)", test.inputTag, test.inputValue)
+
+		testEqual(got, test.want, message, t)
+	}
+}
+
+func TestTag_hasValues(t *testing.T) {
+	tests := []struct {
+		inputTag    Tag
+		inputValues []string
+		want        bool
+	}{
+		{
+			Tag{Values: []string{"present", "also present"}},
+			[]string{"present", "also present"},
+			true,
+		},
+		{
+			Tag{Values: []string{"present", "also present"}},
+			[]string{"present", "missing"},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.inputTag.hasValues(test.inputValues)
+		message := fmt.Sprintf("%#v.hasValues(%#v)", test.inputTag, test.inputValues)
+
+		testEqual(got, test.want, message, t)
+	}
+}
+
+func TestTag_satisfiesTag(t *testing.T) {
+	tests := []struct {
+		inputTag Tag
+		checkTag Tag
+		want     bool
+	}{
+		{
+			Tag{Name: "matched name"},
+			Tag{Name: "matched name"},
+			true,
+		},
+		{
+			Tag{Name: "matched name"},
+			Tag{Name: "unmatched name"},
+			false,
+		},
+		{
+			Tag{Name: "matched name", Values: []string{"matched value", "extra value"}},
+			Tag{Name: "matched name", Values: []string{"matched value"}},
+			true,
+		},
+		{
+			Tag{Name: "matched name", Values: []string{"matched value", "extra value"}},
+			Tag{Name: "matched name", Values: []string{"unmatched value"}},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.inputTag.satisfiesTag(test.checkTag)
+		message := fmt.Sprintf("%#v.satisfiesTag(%#v)", test.inputTag, test.checkTag)
+
+		testEqual(got, test.want, message, t)
+	}
+}

--- a/internal/splunkconfig/config/tags.go
+++ b/internal/splunkconfig/config/tags.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// Tags is a list of Tag objects.
+type Tags []Tag
+
+// satisfiesTag returns true if a given Tag is satisfied by this Tags object.
+func (t Tags) satisfiesTag(checkTag Tag) bool {
+	for _, tag := range t {
+		if tag.satisfiesTag(checkTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// satisfiesTags returns true if all given Tags are satisfied by this Tags object.
+func (t Tags) satisfiesTags(checkTags Tags) bool {
+	for _, checkTag := range checkTags {
+		if !t.satisfiesTag(checkTag) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/splunkconfig/config/tags_test.go
+++ b/internal/splunkconfig/config/tags_test.go
@@ -1,0 +1,101 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTags_satisfiesTag(t *testing.T) {
+	tests := []struct {
+		inputTags Tags
+		checkTag  Tag
+		want      bool
+	}{
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tag{Name: "matched name", Values: []string{"matched value"}},
+			true,
+		},
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tag{Name: "unmatched name", Values: []string{"matched value"}},
+			false,
+		},
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tag{Name: "matched name", Values: []string{"unmatched value"}},
+			false,
+		},
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tag{Name: "unmatched name", Values: []string{"unmatched value"}},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.inputTags.satisfiesTag(test.checkTag)
+		message := fmt.Sprintf("%#v.satisfiesTag(%#v)", test.inputTags, test.checkTag)
+
+		testEqual(got, test.want, message, t)
+	}
+}
+
+func TestTags_satisfiesTags(t *testing.T) {
+	tests := []struct {
+		inputTags Tags
+		checkTags Tags
+		want      bool
+	}{
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			true,
+		},
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tags{
+				{Name: "matched name", Values: []string{"matched value"}},
+				{Name: "unmatched name", Values: []string{"matched value"}},
+			},
+			false,
+		},
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tags{
+				{Name: "matched name", Values: []string{"matched value"}},
+				{Name: "matched name", Values: []string{"unmatched value"}},
+			},
+			false,
+		},
+		{
+			Tags{{Name: "matched name", Values: []string{"matched value"}}},
+			Tags{
+				{Name: "matched name", Values: []string{"matched value"}},
+				{Name: "unmatched name", Values: []string{"unmatched value"}},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		got := test.inputTags.satisfiesTags(test.checkTags)
+		message := fmt.Sprintf("%#v.satisfiesTags(%#v)", test.inputTags, test.checkTags)
+
+		testEqual(got, test.want, message, t)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
This PR adds Tags as a concept for the configuration, and adds them to Apps.

Resource `splunkconfig_app_ids` can now filter on specified tags to only return IDs for apps that satisfy the requested tags.

Tags are likely to be added to other configuration types as needed in the future.