### PR TITLE
index names can contain wildcards in srchIndexesAllowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.2 (September 28, 2021)
+
+FIXES:
+
+* **Schema Change**: Index names can have asterisks (*) for `srchIndexesAllowed`.
+
 ## 1.3.1 (September 27, 2021)
 
 FIXES:

--- a/internal/splunkconfig/config/indexname.go
+++ b/internal/splunkconfig/config/indexname.go
@@ -32,7 +32,7 @@ func (indexName IndexName) validate() error {
 	kvstoreRegex := regexp.MustCompile("kvstore")
 
 	// NOTE: we allow leading underscores, because not all Index objects are new indexes, some describe defaults
-	generalRegex := regexp.MustCompile("^[a-z0-9_][a-z0-9_-]+$")
+	generalRegex := regexp.MustCompile("^[a-z0-9_][a-z0-9_-]*$")
 
 	if kvstoreRegex.MatchString(string(indexName)) {
 		return fmt.Errorf("index name (%s) can not contain the word kvstore", indexName)
@@ -40,6 +40,18 @@ func (indexName IndexName) validate() error {
 
 	if !generalRegex.MatchString(string(indexName)) {
 		return fmt.Errorf("index name (%s) must consist of only numbers, lowercase letters, underscores, and hyphens, and must not beigin with a hyphen", indexName)
+	}
+
+	return nil
+}
+
+// validatePattern returns an error if IndexName is invalid as an pattern, suitable to use in srchIndexesAllowed, etc.
+func (indexName IndexName) validatePattern() error {
+	// same pattern as generalRegex in validate(), but asterisk permitted anywhere
+	patternRegex := regexp.MustCompile("^[*a-z0-9_][*a-z0-9_-]*$")
+
+	if !patternRegex.MatchString(string(indexName)) {
+		return fmt.Errorf("index name (%s) can only consist of numbers, lowercase letters, underscores, hyphens, and asterisks to be a valid index pattern", indexName)
 	}
 
 	return nil

--- a/internal/splunkconfig/config/indexname_test.go
+++ b/internal/splunkconfig/config/indexname_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -22,6 +23,7 @@ import (
 func TestIndexName_validate(t *testing.T) {
 	tests := validatorTestCases{
 		{IndexName(""), true},
+		{IndexName("*"), true},
 		{IndexName("-blah"), true},
 		{IndexName("_blah"), false},
 		{IndexName("mykvstore"), true},
@@ -31,4 +33,30 @@ func TestIndexName_validate(t *testing.T) {
 	}
 
 	tests.test(t)
+}
+
+// validateIndexName should return an error when one is expected.
+func TestIndexName_validatePattern(t *testing.T) {
+	tests := []struct {
+		input     IndexName
+		wantError bool
+	}{
+		{IndexName(""), true},
+		{IndexName("*"), false},
+		{IndexName("_*"), false},
+		{IndexName("-blah"), true},
+		{IndexName("_blah"), false},
+		// mykvstore isn't a valid index name, but it's a valid _pattern_
+		{IndexName("mykvstore"), false},
+		{IndexName("mail@company"), true},
+		{IndexName("mail.company"), true},
+		{IndexName("summary7days"), false},
+	}
+
+	for _, test := range tests {
+		gotError := test.input.validatePattern() != nil
+		message := fmt.Sprintf("%#v.validatePattern() returned error?", test.input)
+
+		testEqual(gotError, test.wantError, message, t)
+	}
 }

--- a/internal/splunkconfig/config/indexnames.go
+++ b/internal/splunkconfig/config/indexnames.go
@@ -39,6 +39,17 @@ func (indexNames IndexNames) validate() error {
 	return allValidNoDuplicates(uniqueValidators(indexNames))
 }
 
+// validatePattern returns an error if any members of IndexNames is an invalid pattern.
+func (indexNames IndexNames) validatePattern() error {
+	for _, indexName := range indexNames {
+		if err := indexName.validatePattern(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // deduplicatedSorted returns a deduplicated and sorted IndexNames from one that potentiall has duplication.
 func (indexNames IndexNames) deduplicatedSorted() IndexNames {
 	deduplicatedNames := uniqueUIDsOfUIDers(indexNames)

--- a/internal/splunkconfig/config/indexnames_test.go
+++ b/internal/splunkconfig/config/indexnames_test.go
@@ -39,6 +39,30 @@ func TestIndexNames_validate(t *testing.T) {
 	tests.test(t)
 }
 
+// IndexNames.validatePattern should return an error when expected.
+func TestIndexNames_validatePattern(t *testing.T) {
+	tests := []struct {
+		input     IndexNames
+		wantError bool
+	}{
+		{
+			IndexNames{"fine", "alsofine", "*wildcardsfine"},
+			false,
+		},
+		{
+			IndexNames{"fine", "!fine", "also_fine"},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		gotError := test.input.validatePattern() != nil
+		message := fmt.Sprintf("%#v.validatePattern() returned error?", test.input)
+
+		testEqual(gotError, test.wantError, message, t)
+	}
+}
+
 func TestIndexNames_deduplicatedSorted(t *testing.T) {
 	indexNames := IndexNames{
 		"a",

--- a/internal/splunkconfig/config/role.go
+++ b/internal/splunkconfig/config/role.go
@@ -41,7 +41,7 @@ func (r Role) validate() error {
 		return err
 	}
 
-	if err := r.SearchIndexesAllowed.validate(); err != nil {
+	if err := r.SearchIndexesAllowed.validatePattern(); err != nil {
 		return err
 	}
 

--- a/internal/splunkconfig/config/suite_test.go
+++ b/internal/splunkconfig/config/suite_test.go
@@ -70,6 +70,18 @@ func TestSuite_validate(t *testing.T) {
 			},
 			true,
 		},
+		{
+			// SrchIndexesAllowed uses wildcards
+			Suite{
+				Roles: Roles{
+					Role{
+						Name:                 "role_a",
+						SearchIndexesAllowed: IndexNames{"*"},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	tests.test(t)


### PR DESCRIPTION
Closes #18 

This MR changes validation of index names to permit asterisks when the name is used as a pattern, such as in srchIndexesAllowed.