### PR TITLE
Add Collections

### DIFF
--- a/internal/provider/apppackage_test.go
+++ b/internal/provider/apppackage_test.go
@@ -36,7 +36,10 @@ func TestAccResourceAppPackage(t *testing.T) {
 					resource.TestMatchResourceAttr("splunkconfig_app_package.indexes", "files.0.content", regexp.MustCompile("version = 1.0.0")),
 					resource.TestCheckResourceAttr("splunkconfig_app_package.indexes", "files.0.path", "default/app.conf"),
 					resource.TestCheckResourceAttr("splunkconfig_app_package.indexes", "files.1.path", "default/indexes.conf"),
-					resource.TestMatchResourceAttr("splunkconfig_app_package.indexes", "files.1.content", regexp.MustCompile("[original_index]")),
+					resource.TestMatchResourceAttr("splunkconfig_app_package.indexes", "files.1.content", regexp.MustCompile(`\[original_index]`)),
+					resource.TestCheckResourceAttr("splunkconfig_app_package.indexes", "files.2.path", "default/collections.conf"),
+					resource.TestMatchResourceAttr("splunkconfig_app_package.indexes", "files.2.content", regexp.MustCompile(`\[collection_a]`)),
+					resource.TestMatchResourceAttr("splunkconfig_app_package.indexes", "files.2.content", regexp.MustCompile("field.field_a = string")),
 				),
 			},
 
@@ -98,6 +101,10 @@ apps:
     version: 1.0.0
     indexes:
       - name: original_index
+    collections:
+      - name: collection_a
+        fields:
+          field_a: string
 EOT
 }
 

--- a/internal/splunkconfig/config/app.go
+++ b/internal/splunkconfig/config/app.go
@@ -35,6 +35,7 @@ type App struct {
 	IndexesPlaceholder IndexesPlaceholder `yaml:"indexes"`
 	RolesPlaceholder   RolesPlaceholder   `yaml:"roles"`
 	LookupsPlaceholder LookupsPlaceholder `yaml:"lookups"`
+	Collections        Collections
 	ACL                ACL
 	Tags               Tags
 }
@@ -58,6 +59,7 @@ func (app App) validate() error {
 		"IndexesPlaceholder": app.IndexesPlaceholder,
 		"RolesPlaceholder":   app.RolesPlaceholder,
 		"LookupsPlaceholder": app.LookupsPlaceholder,
+		"Collections":        app.Collections,
 		"ACL":                app.ACL,
 	}
 
@@ -163,6 +165,7 @@ func (app App) FileContenters() FileContenters {
 	contenters := FileContenters{app.appConfFile()}
 	contenters = append(contenters, NewFileContentersFromList(app.ConfFiles)...)
 	contenters = append(contenters, app.LookupsPlaceholder.Lookups.fileContenters()...)
+	contenters = append(contenters, app.Collections.confFile())
 
 	// .meta at the end like a bow
 	contenters = append(contenters, app.metaConfFile())

--- a/internal/splunkconfig/config/collection.go
+++ b/internal/splunkconfig/config/collection.go
@@ -39,3 +39,36 @@ func (collection Collection) validate() error {
 
 	return nil
 }
+
+// stanzaName returns the stanza's name for a Collection.
+func (collection Collection) stanzaName() string {
+	return string(collection.Name)
+}
+
+// stanzaValues returns the StanzaValues for a Collection.
+func (collection Collection) stanzaValues() StanzaValues {
+	stanzaValues := StanzaValues{}
+
+	if collection.EnforceTypes {
+		stanzaValues["enforceTypes"] = fmt.Sprintf("%v", collection.EnforceTypes)
+	}
+
+	if collection.Replicate {
+		stanzaValues["replicate"] = fmt.Sprintf("%v", collection.Replicate)
+	}
+
+	for fieldName, fieldType := range collection.Fields {
+		fieldKey := fmt.Sprintf("field.%s", fieldName)
+		stanzaValues[fieldKey] = string(fieldType)
+	}
+
+	return stanzaValues
+}
+
+// stanza returns the Stanza for a Collection.
+func (collection Collection) stanza() Stanza {
+	return Stanza{
+		Name:   collection.stanzaName(),
+		Values: collection.stanzaValues(),
+	}
+}

--- a/internal/splunkconfig/config/collection.go
+++ b/internal/splunkconfig/config/collection.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "fmt"
+
+// Collection represents a KVStore Collection.
+type Collection struct {
+	Name         string
+	EnforceTypes bool
+	Fields       CollectionFields
+	Replicate    bool
+}
+
+// validate returns an error if Collection is invalid. It is invalid if it
+// has invalid:
+//   * Name
+//   * Fields
+func (collection Collection) validate() error {
+	if len(collection.Name) == 0 {
+		return fmt.Errorf("Collection name can not be empty")
+	}
+
+	if err := collection.Fields.validate(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/splunkconfig/config/collection_test.go
+++ b/internal/splunkconfig/config/collection_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestCollection_validate(t *testing.T) {
+	tests := validatorTestCases{
+		{
+			Collection{},
+			true,
+		},
+		{
+			Collection{
+				Name: "validName",
+			},
+			false,
+		},
+		{
+			Collection{
+				Name: "validName",
+				Fields: CollectionFields{
+					"validField":   "string",
+					"invalidField": "invalidType",
+				},
+			},
+			true,
+		},
+	}
+
+	tests.test(t)
+}

--- a/internal/splunkconfig/config/collection_test.go
+++ b/internal/splunkconfig/config/collection_test.go
@@ -42,3 +42,35 @@ func TestCollection_validate(t *testing.T) {
 
 	tests.test(t)
 }
+
+func TestCollection_stanza(t *testing.T) {
+	tests := stanzaDefinerTestCases{
+		{
+			Collection{
+				Name: "test_collection",
+			},
+			Stanza{
+				Name:   "test_collection",
+				Values: StanzaValues{},
+			},
+		},
+		{
+			Collection{
+				Name: "test_collection",
+				Fields: CollectionFields{
+					"bool_field":   "bool",
+					"string_field": "string",
+				},
+			},
+			Stanza{
+				Name: "test_collection",
+				Values: StanzaValues{
+					"field.bool_field":   "bool",
+					"field.string_field": "string",
+				},
+			},
+		},
+	}
+
+	tests.test(t)
+}

--- a/internal/splunkconfig/config/collectionfields.go
+++ b/internal/splunkconfig/config/collectionfields.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// CollectionFields is a mapping of field names to CollectionFieldType.
+type CollectionFields map[string]CollectionFieldType
+
+// validate returns an error if CollectionFields is invalid. It is invalid if
+// any member has invalid:
+//   * CollectionFieldType
+func (collectionFields CollectionFields) validate() error {
+	for _, fieldType := range collectionFields {
+		if err := fieldType.validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/splunkconfig/config/collectionfields_test.go
+++ b/internal/splunkconfig/config/collectionfields_test.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestCollectionFields_validate(t *testing.T) {
+	tests := validatorTestCases{
+		{
+			CollectionFields{"validA": "bool", "validB": "string", "validC": "time"},
+			false,
+		},
+		{
+			CollectionFields{"validA": "string", "invalidA": "invalid"},
+			true,
+		},
+	}
+
+	tests.test(t)
+}

--- a/internal/splunkconfig/config/collectionfieldtype.go
+++ b/internal/splunkconfig/config/collectionfieldtype.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "fmt"
+
+// CollectionFieldType represents the type value for a Collection's Field.
+type CollectionFieldType string
+
+const (
+	CollectionFieldTypeNumber CollectionFieldType = "number"
+	CollectionFieldTypeBool   CollectionFieldType = "bool"
+	CollectionFieldTypeString CollectionFieldType = "string"
+	CollectionFieldTypeTime   CollectionFieldType = "time"
+)
+
+// validate returns an error if CollectionFieldType is invalid. It is invalid if:
+// * it isn't one of the defined constants
+func (collectionFieldType CollectionFieldType) validate() error {
+	switch collectionFieldType {
+	case CollectionFieldTypeNumber, CollectionFieldTypeBool, CollectionFieldTypeString, CollectionFieldTypeTime:
+		break
+	default:
+		return fmt.Errorf("invalid CollectionFieldType value: %s", collectionFieldType)
+	}
+
+	return nil
+}

--- a/internal/splunkconfig/config/collectionfieldtype_test.go
+++ b/internal/splunkconfig/config/collectionfieldtype_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestCollectionFieldType_validate(t *testing.T) {
+	tests := validatorTestCases{
+		{
+			CollectionFieldType(""),
+			true,
+		},
+		{
+			CollectionFieldType("invalid"),
+			true,
+		},
+		{
+			CollectionFieldType("string"),
+			false,
+		},
+		{
+			CollectionFieldType("number"),
+			false,
+		},
+		{
+			CollectionFieldType("bool"),
+			false,
+		},
+		{
+			CollectionFieldType("time"),
+			false,
+		},
+	}
+
+	tests.test(t)
+}

--- a/internal/splunkconfig/config/collections.go
+++ b/internal/splunkconfig/config/collections.go
@@ -37,3 +37,11 @@ func (collections Collections) stanzas() Stanzas {
 
 	return stanzas
 }
+
+// confFile returns the ConfFile for Collections.
+func (collections Collections) confFile() ConfFile {
+	return ConfFile{
+		Name:    "collections",
+		Stanzas: collections.stanzas(),
+	}
+}

--- a/internal/splunkconfig/config/collections.go
+++ b/internal/splunkconfig/config/collections.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+type Collections []Collection
+
+// validate returns an error if any member Collection is invalid.
+func (collections Collections) validate() error {
+	for _, collection := range collections {
+		if err := collection.validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// stanzas returns the Stanzas for Collections.
+func (collections Collections) stanzas() Stanzas {
+	stanzas := make(Stanzas, len(collections))
+
+	for i, collection := range collections {
+		stanzas[i] = collection.stanza()
+	}
+
+	return stanzas
+}

--- a/internal/splunkconfig/config/collections_test.go
+++ b/internal/splunkconfig/config/collections_test.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestCollections_stanzas(t *testing.T) {
+	tests := stanzasDefinerTestCases{
+		{
+			Collections{
+				{Name: "collectionA"},
+				{Name: "collectionB", Fields: CollectionFields{"fieldA": "string"}},
+			},
+			Stanzas{
+				{Name: "collectionA", Values: StanzaValues{}},
+				{Name: "collectionB", Values: StanzaValues{"field.fieldA": "string"}},
+			},
+		},
+	}
+
+	tests.test(t)
+}


### PR DESCRIPTION
Closes #20 

This MR adds `collections` to an `app` definition.

A `collection` can only be defined directly in an `app` at this time, as there isn't really a use case I can think of for defining anything about a `collection` _outside_ of an `app`.