### PR TITLE
Generate configuration with Lookup from CSV file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 builds:
-  - env:
+  - &common_build_config
+    env:
       # goreleaser does not work with CGO, it could also complicate
       # usage by users in CI/CD systems like Terraform Cloud where
       # they are unable to install libraries.
@@ -23,6 +24,10 @@ builds:
       - goos: darwin
         goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
+  - <<: *common_build_config
+    id: template-lookup-csv
+    main: ./cmd/template-lookup-csv/main.go
+    binary: 'tools/import-lookup-csv'
 archives:
   - format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'

--- a/cmd/template-lookup-csv/main.go
+++ b/cmd/template-lookup-csv/main.go
@@ -28,7 +28,7 @@ func main() {
 	csvFilename := flag.String("csvFilename", "", "CSV file to import (required)")
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "\template-lookup-csv: Print splunkconfig YAML from CSV file\n\n\n")
+		fmt.Fprintf(os.Stderr, "\ntemplate-lookup-csv: Print YAML for a Lookup from CSV content.\n\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 	}

--- a/cmd/template-lookup-csv/main.go
+++ b/cmd/template-lookup-csv/main.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"terraform-provider-splunkconfig/internal/splunkconfig/config"
+
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	lookupName := flag.String("lookupName", "", "Name to give the new Lookup (required)")
+	csvFilename := flag.String("csvFilename", "", "CSV file to import (required)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "\template-lookup-csv: Print splunkconfig YAML from CSV file\n\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+	argsErrors := []string{}
+	if *lookupName == "" {
+		argsErrors = append(argsErrors, "lookupName is required")
+	}
+	if *csvFilename == "" {
+		argsErrors = append(argsErrors, "csvFilename is required")
+	}
+	if len(argsErrors) > 0 {
+		flag.Usage()
+		fmt.Fprintf(os.Stderr, "\nArgument errors:\n")
+		for _, argsError := range argsErrors {
+			fmt.Fprintf(os.Stderr, "  %s\n", argsError)
+		}
+		os.Exit(1)
+	}
+
+	csvFileReader, err := os.Open(*csvFilename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to open %s: %s\n", *csvFilename, err)
+		os.Exit(1)
+	}
+	defer csvFileReader.Close()
+
+	lookup, err := config.NewLookupFromIoReader(*lookupName, csvFileReader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to create new lookup from CSV: %s\n", err)
+		os.Exit(1)
+	}
+
+	suite := config.Suite{
+		Lookups: config.Lookups{lookup},
+	}
+
+	yamlBytes, err := yaml.Marshal(suite)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to marshal lookup: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(string(yamlBytes))
+}

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,0 +1,27 @@
+---
+page_title: "Command Line Tools"
+subcategory: ""
+description: |-
+  Included command line tools
+---
+
+# Placement
+
+Tools are included in this provider under the `tools/` directory of the provider.
+
+After performing `terraform init`, this directory should exist, relative to the initialized root module, as:
+
+```
+.terraform/providers/registry.terraform.io/splunk/splunkconfig/<version>/<architecture>/tools
+```
+
+# Usage
+
+## template-lookup-csv
+
+Print YAML for a Lookup from CSV content.
+
+### Arguments
+
+- **csvFilename** (required) Path to CSV content. The CSV file must include a header row with field names.
+- **lookupName** (required) Name to give the generated Lookup.

--- a/internal/splunkconfig/config/lookup.go
+++ b/internal/splunkconfig/config/lookup.go
@@ -27,9 +27,9 @@ import (
 type Lookup struct {
 	Name            string
 	Fields          LookupFields
-	ExternalCommand string `yaml:"external_cmd"`
-	ExternalType    string `yaml:"external_type"`
-	Collection      string
+	ExternalCommand string `yaml:"external_cmd,omitempty"`
+	ExternalType    string `yaml:"external_type,omitempty"`
+	Collection      string `yaml:"collection,omitempty"`
 	Rows            LookupRows
 }
 

--- a/internal/splunkconfig/config/lookupfield.go
+++ b/internal/splunkconfig/config/lookupfield.go
@@ -19,9 +19,9 @@ import "fmt"
 // LookupField is a single field of a lookup.
 type LookupField struct {
 	Name            string
-	Required        bool
-	DefaultRowField bool `yaml:"default_row_field"`
-	Default         string
+	Required        bool   `yaml:"required,omitempty"`
+	DefaultRowField bool   `yaml:"default_row_field,omitempty"`
+	Default         string `yaml:"default,omitempty"`
 }
 
 // validate returns an error if LookupField is invalid. It is invalid if it:

--- a/internal/splunkconfig/config/lookuprow.go
+++ b/internal/splunkconfig/config/lookuprow.go
@@ -19,7 +19,7 @@ import "fmt"
 // LookupRow is a map of field names to field values.
 type LookupRow struct {
 	// LookupName is used to indirectly associate this Row with a LookupDefinition
-	LookupName string `yaml:"lookup_name"`
+	LookupName string `yaml:"lookup_name,omitempty"`
 	Values     LookupValues
 }
 

--- a/internal/splunkconfig/config/lookuprow.go
+++ b/internal/splunkconfig/config/lookuprow.go
@@ -61,3 +61,18 @@ func (lookupRow LookupRow) withDefaultLookupValues(lookupValues LookupValues) Lo
 func (lookupRow LookupRow) withValuesForLookupFromDefaultLookupValuesDefiner(lookup Lookup, definer defaultLookupValuesDefiner) LookupRow {
 	return lookupRow.withDefaultLookupValues(defaultLookupValuesForLookup(lookup, definer))
 }
+
+// newLookupRowWithFieldsAndValues creates a new LookupRow from the given list of field names and values.
+func newLookupRowWithFieldsAndValues(fieldNames []string, fieldValues []string) (newLookupRow LookupRow, err error) {
+	if len(fieldNames) != len(fieldValues) {
+		return LookupRow{}, fmt.Errorf("unable to create newLookupRowWithFieldsValues, fields length (%d) different from values length (%d)", len(fieldNames), len(fieldValues))
+	}
+
+	newLookupRow.Values = make(LookupValues, len(fieldNames))
+
+	for i, fieldName := range fieldNames {
+		newLookupRow.Values[fieldName] = fieldValues[i]
+	}
+
+	return newLookupRow, nil
+}

--- a/internal/splunkconfig/config/lookuprow_test.go
+++ b/internal/splunkconfig/config/lookuprow_test.go
@@ -74,3 +74,46 @@ func TestLookupRow_valuesForLookupFields(t *testing.T) {
 		testEqual(gotValues, test.wantValues, message, t)
 	}
 }
+
+func TestLookupRow_newLookupRowWithFieldsAndValues(t *testing.T) {
+	tests := []struct {
+		inputFields   []string
+		inputValues   []string
+		wantLookupRow LookupRow
+		wantError     bool
+	}{
+		// more fields than values
+		{
+			[]string{"fieldA"},
+			[]string{},
+			LookupRow{},
+			true,
+		},
+		// more values than fields
+		{
+			[]string{},
+			[]string{"valueA"},
+			LookupRow{},
+			true,
+		},
+		// just right
+		{
+			[]string{"fieldA", "fieldB"},
+			[]string{"valueA", "valueB"},
+			LookupRow{
+				Values: LookupValues{"fieldA": "valueA", "fieldB": "valueB"},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		gotLookupRow, err := newLookupRowWithFieldsAndValues(test.inputFields, test.inputValues)
+		gotError := err != nil
+		lookupRowMessage := fmt.Sprintf("newLookupRowWithFieldsAndValues(%#v, %#v) = %#v, want %#v", test.inputFields, test.inputValues, gotLookupRow, test.wantLookupRow)
+		errorMessage := fmt.Sprintf("newLookupRowWithFieldsAndValues(%#v, %#v) returned error?", test.inputFields, test.inputValues)
+
+		testEqual(gotLookupRow, test.wantLookupRow, lookupRowMessage, t)
+		testEqual(gotError, test.wantError, errorMessage, t)
+	}
+}

--- a/internal/splunkconfig/config/lookupvalues.go
+++ b/internal/splunkconfig/config/lookupvalues.go
@@ -91,3 +91,21 @@ func (lookupValues LookupValues) hasFieldNames(fieldNames []string) bool {
 
 	return true
 }
+
+// MarshalYAML overrides the default YAML marshaling of LookupValues to remove empty values.
+func (lookupValues LookupValues) MarshalYAML() (interface{}, error) {
+	// effectively passthrough if lookupValues is the zero-value for a map
+	if lookupValues == nil {
+		return nil, nil
+	}
+
+	marshalValues := make(map[string]string, len(lookupValues))
+
+	for key, value := range lookupValues {
+		if value != "" {
+			marshalValues[key] = value
+		}
+	}
+
+	return marshalValues, nil
+}

--- a/internal/splunkconfig/config/lookupvalues_test.go
+++ b/internal/splunkconfig/config/lookupvalues_test.go
@@ -130,3 +130,28 @@ func TestLookupValues_hasFieldNames(t *testing.T) {
 		testEqual(gotBool, test.wantBool, message, t)
 	}
 }
+
+func TestLookupValues_MarshalYAML(t *testing.T) {
+	tests := yamlMarshalerTestCases{
+		// zero-value for LookupValues is unchanged
+		{
+			LookupValues(nil),
+			nil,
+			false,
+		},
+		// "normal" key=value
+		{
+			LookupValues{"fieldA": "valueA", "fieldB": "valueB"},
+			map[string]string{"fieldA": "valueA", "fieldB": "valueB"},
+			false,
+		},
+		// empty keys removed
+		{
+			LookupValues{"fieldA": "valueA", "fieldB": ""},
+			map[string]string{"fieldA": "valueA"},
+			false,
+		},
+	}
+
+	tests.test(t)
+}

--- a/internal/splunkconfig/config/suite.go
+++ b/internal/splunkconfig/config/suite.go
@@ -17,8 +17,9 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 // Suite is a type that represents a collection of component configurations.

--- a/internal/splunkconfig/config/suite.go
+++ b/internal/splunkconfig/config/suite.go
@@ -23,15 +23,15 @@ import (
 
 // Suite is a type that represents a collection of component configurations.
 type Suite struct {
-	Indexes    Indexes
-	Roles      Roles
-	SAMLGroups SAMLGroups `yaml:"saml_groups"`
-	Lookups    Lookups
-	Apps       Apps
-	Users      Users
+	Indexes    Indexes    `yaml:"indexes,omitempty"`
+	Roles      Roles      `yaml:"roles,omitempty"`
+	SAMLGroups SAMLGroups `yaml:"saml_groups,omitempty"`
+	Lookups    Lookups    `yaml:"lookups,omitempty"`
+	Apps       Apps       `yaml:"apps,omitempty"`
+	Users      Users      `yaml:"users,omitempty"`
 	// Anchors isn't actually part of the configuration, it just gives you somewhere to define
 	// YAML anchors while still disallowing unknown keys.
-	Anchors interface{}
+	Anchors interface{} `yaml:"anchors,omitempty"`
 }
 
 // validate returns an error if any of a Suite's configurations are invalid.

--- a/internal/splunkconfig/config/yamlmarshalertestcase.go
+++ b/internal/splunkconfig/config/yamlmarshalertestcase.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// yamlMarshalerTestCase defines a single test case for a yaml.Marshaler.
+type yamlMarshalerTestCase struct {
+	input         yaml.Marshaler
+	wantInterface interface{}
+	wantError     bool
+}
+
+// test performs the test defined in a yamlMarshalerTestCase.
+func (testCase yamlMarshalerTestCase) test(t *testing.T) {
+	gotInterface, err := testCase.input.MarshalYAML()
+	gotError := err != nil
+
+	messageError := fmt.Sprintf("%#v.MarshalYAML() returned error? %v", testCase.input, gotError)
+	testEqual(gotError, testCase.wantError, messageError, t)
+
+	messageContent := fmt.Sprintf("%#v.MarshalYAML() = %#v, want %#v", testCase.input, gotInterface, testCase.wantInterface)
+	testEqual(gotInterface, testCase.wantInterface, messageContent, t)
+}

--- a/internal/splunkconfig/config/yamlmarshalertestcases.go
+++ b/internal/splunkconfig/config/yamlmarshalertestcases.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+// yamlMarshalerTestCases is a list of yamlMarshalerTestCase objects.
+type yamlMarshalerTestCases []yamlMarshalerTestCase
+
+// test performs the test defined in each yamlMarshalerTestCase in yamlMarshalerTestCases.
+func (testCases yamlMarshalerTestCases) test(t *testing.T) {
+	for _, testCase := range testCases {
+		testCase.test(t)
+	}
+}


### PR DESCRIPTION
This PR adds functionality to generate a configuration for this provider that includes a Lookup with its content derived from a CSV file.

The CLI tool that performs this action gets built into the provider's zip file, as `tools/template-lookup-csv`.  This allows anyone who has already fetched the provider using Terraform to make use of the tool without having to build it themselves.

The use case for this functionality is to ease transitioning from manually-maintained lookup content to using this provider to define dynamic lookup content.