### PR TITLE
capability_validate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
 
       - name: fmt
-        run: gofmt -l . && test -z $(gofmt -l .)
+        run: go fmt ./... && git diff && test -z "$(git status --porcelain)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.1 (March 30, 2023)
+
+FEATURES:
+
+* **New Capability Validation**: Adding `-` as a valid character in capability names
+
 ## 1.7.0 (February 8, 2022)
 
 FEATURES:

--- a/internal/splunkconfig/config/appid.go
+++ b/internal/splunkconfig/config/appid.go
@@ -26,6 +26,7 @@ type AppID string
 // * id must adhere to these cross-platform folder name restrictions:
 //   - must contain only letters, numbers, "." (dot), and "_" (underscore)
 //     characters.
+//
 // "-" (dash) characters are also permitted as many official Splunk apps have them in their IDs
 func (appID AppID) validate() error {
 	validRegex := regexp.MustCompile("^[A-Za-z0-9_.-]+$")

--- a/internal/splunkconfig/config/appid.go
+++ b/internal/splunkconfig/config/appid.go
@@ -24,8 +24,8 @@ type AppID string
 
 // validate returns an error if AppID is invalid.  As per Splunk's app.conf .spec:
 // * id must adhere to these cross-platform folder name restrictions:
-//  * must contain only letters, numbers, "." (dot), and "_" (underscore)
-//    characters.
+//   - must contain only letters, numbers, "." (dot), and "_" (underscore)
+//     characters.
 // "-" (dash) characters are also permitted as many official Splunk apps have them in their IDs
 func (appID AppID) validate() error {
 	validRegex := regexp.MustCompile("^[A-Za-z0-9_.-]+$")

--- a/internal/splunkconfig/config/capabilityname.go
+++ b/internal/splunkconfig/config/capabilityname.go
@@ -24,9 +24,9 @@ type CapabilityName string
 
 // validate returns an error if the CapabilityName is invalid. Splunk's documentation defines valid capability names:
 //
-// Only alphanumeric characters and "_" (underscore) are allowed in capability names.
+// Only alphanumeric characters, "_" (underscore), and "-" (dash) are allowed in capability names.
 func (capabilityName CapabilityName) validate() error {
-	validRegex := regexp.MustCompile("^[a-z0-9_-]+$")
+	validRegex := regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 
 	if !validRegex.MatchString(string(capabilityName)) {
 		return fmt.Errorf("invalid CapabilityName %s, may only consist of alphanumeric characters, underscores, and dashes", capabilityName)

--- a/internal/splunkconfig/config/capabilityname.go
+++ b/internal/splunkconfig/config/capabilityname.go
@@ -29,7 +29,7 @@ func (capabilityName CapabilityName) validate() error {
 	validRegex := regexp.MustCompile("^[a-z0-9_-]+$")
 
 	if !validRegex.MatchString(string(capabilityName)) {
-		return fmt.Errorf("invalid CapabilityName %s, may only consist of lowercase letters, numbers, underscores, and dashes", capabilityName)
+		return fmt.Errorf("invalid CapabilityName %s, may only consist of alphanumeric characters, underscores, and dashes", capabilityName)
 	}
 
 	return nil

--- a/internal/splunkconfig/config/capabilityname.go
+++ b/internal/splunkconfig/config/capabilityname.go
@@ -26,10 +26,10 @@ type CapabilityName string
 //
 // Only alphanumeric characters and "_" (underscore) are allowed in capability names.
 func (capabilityName CapabilityName) validate() error {
-	validRegex := regexp.MustCompile("^[a-zA-Z0-9_]+$")
+	validRegex := regexp.MustCompile("^[a-z0-9_-]+$")
 
 	if !validRegex.MatchString(string(capabilityName)) {
-		return fmt.Errorf("invalid CapabilityName %s, may only consist of alphanumeric characters and underscores", capabilityName)
+		return fmt.Errorf("invalid CapabilityName %s, may only consist of lowercase letters, numbers, underscores, and dashes", capabilityName)
 	}
 
 	return nil

--- a/internal/splunkconfig/config/capabilityname_test.go
+++ b/internal/splunkconfig/config/capabilityname_test.go
@@ -20,7 +20,7 @@ func TestCapability_validate(t *testing.T) {
 	tests := validatorTestCases{
 		// empty name is invalid
 		{CapabilityName(""), true},
-		// valid name contains lowercase, uppercase, number, underscore
+		// valid name contains lowercase, uppercase, number, underscore, dash
 		{CapabilityName("aA_1-"), false},
 	}
 

--- a/internal/splunkconfig/config/capabilityname_test.go
+++ b/internal/splunkconfig/config/capabilityname_test.go
@@ -20,10 +20,8 @@ func TestCapability_validate(t *testing.T) {
 	tests := validatorTestCases{
 		// empty name is invalid
 		{CapabilityName(""), true},
-		// symbols (including dashes) are invalid
-		{CapabilityName("-"), true},
 		// valid name contains lowercase, uppercase, number, underscore
-		{CapabilityName("aA_1"), false},
+		{CapabilityName("aA_1-"), false},
 	}
 
 	tests.test(t)

--- a/internal/splunkconfig/config/collection.go
+++ b/internal/splunkconfig/config/collection.go
@@ -26,8 +26,8 @@ type Collection struct {
 
 // validate returns an error if Collection is invalid. It is invalid if it
 // has invalid:
-//   * Name
-//   * Fields
+//   - Name
+//   - Fields
 func (collection Collection) validate() error {
 	if len(collection.Name) == 0 {
 		return fmt.Errorf("Collection name can not be empty")

--- a/internal/splunkconfig/config/collectionfields.go
+++ b/internal/splunkconfig/config/collectionfields.go
@@ -19,7 +19,7 @@ type CollectionFields map[string]CollectionFieldType
 
 // validate returns an error if CollectionFields is invalid. It is invalid if
 // any member has invalid:
-//   * CollectionFieldType
+//   - CollectionFieldType
 func (collectionFields CollectionFields) validate() error {
 	for _, fieldType := range collectionFields {
 		if err := fieldType.validate(); err != nil {


### PR DESCRIPTION
Docs mention that capabilities can only be alphanumeric + underscores, however ITSI roles have capabilities with dashes in them. Need to update the validator. I have commented on the spec file doc and made a comment on internal Slack channel(s) about this.