### PR TITLE
[SAS-9683] add compress/gzip

### DIFF
--- a/internal/splunkconfig/config/app.go
+++ b/internal/splunkconfig/config/app.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -188,7 +189,10 @@ func (app App) WriteTar(path string) (tgzPath string, err error) {
 	}
 	defer tf.Close()
 
-	tw := tar.NewWriter(tf)
+	gz := gzip.NewWriter(tf)
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
 	defer tw.Close()
 
 	for _, contenter := range app.FileContenters() {


### PR DESCRIPTION
Problem: from app inspect: "FAILURE: The provided package archive is not compressed 
            properly. Please, submit properly compressed archive. See: 
            https://dev.splunk.com/enterprise/docs/releaseapps/packageapps/#Third-party-utilities-and-CLI-commands 
            for more info. "

Adding gzip compression to tar archive to actually compress the archive to remove this failure

