### PR TITLE
[SAS-10122] update goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,9 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@f82d6c1c344bcacabba2c841718984797f664a6b # v4.2.0
+        uses: goreleaser/goreleaser-action@v5 # v5.0.0
         with:
+          version: 2
           args: release --clean
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.


### PR DESCRIPTION
Update goreleaser
goreleaser action job failed within the GIthub Action CICD pipeline

Expect Error to be resolved by adding `version: 2` to [.github/workflows/release.yml](https://github.com/splunk/terraform-provider-splunkconfig/pull/55/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)

[Documentation from goreleaser](https://goreleaser.com/errors/version/?h=version+file) describes problem:

- Problem: "only configurations files on version: 2 are supported, yours is version: 0, please update your configuration"
- Solution: "If you get it as a warning, your configuration file is valid in v2, but would benefit with the version header. You can remove the warning by adding this line to your configuration: `version: 2`

 

