### PR TITLE
[SAS-10122] add version to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - &common_build_config
     env:


### PR DESCRIPTION
Tested Locally

For terraform-provider-splunkconfig, we have .gorelease.yml and [.github/workflows/release.yml](https://github.com/splunk/terraform-provider-splunkconfig/blob/main/.github/workflows/release.yml).

the root directory file [.goreleaser.yml](https://github.com/splunk/terraform-provider-splunkconfig/compare/main...kdurril-splunk:terraform-provider-splunkconfig:SAS-10122?expand=1#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689), defines the builds to release



Running goreleaser against the root directory’s [.goreleaser.yml](https://github.com/splunk/terraform-provider-splunkconfig/compare/main...kdurril-splunk:terraform-provider-splunkconfig:SAS-10122?expand=1#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689) without the version: 2 setting and it will show errors:
<img width="1152" alt="Screenshot 2024-08-12 at 12 08 57 PM" src="https://github.com/user-attachments/assets/d614e173-eeb2-4d38-a765-df512a9ee6d6">



After updating, adding version: 2, the run passes:
<img width="1171" alt="Screenshot 2024-08-12 at 12 09 44 PM" src="https://github.com/user-attachments/assets/0205c4c6-10ba-41b5-af4d-76f11246914f">

