### PR TITLE
[SAS-10122] update changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,4 +47,4 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Resolve unmarshall error from https://github.com/splunk/terraform-provider-splunkconfig/actions/runs/10423188034/job/28869353240

`1s
Run goreleaser/goreleaser-action@v5
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.2.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/62de7830-[1](https://github.com/splunk/terraform-provider-splunkconfig/actions/runs/10423188034/job/28869353240#step:5:1)4d3-4ecb-bffe-82c4a6682c35 -f /home/runner/work/_temp/bdc2b8b7-4131-4[12](https://github.com/splunk/terraform-
provider-splunkconfig/actions/runs/10423188034/job/28869353240#step:5:13)3-96dd-7dcd6212954f
GoReleaser 2 installed successfully
/opt/hostedtoolcache/goreleaser-action/2.2.0/x64/goreleaser release --clean
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 50: field skip not found in type config.Changelog
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.2.0/x64/goreleaser' failed with exit code 1`

Updated per https://goreleaser.com/deprecations/#changelogskip

```
changelog.skip[¶](https://goreleaser.com/deprecations/#changelogskip)
since 2024-01-14 (v1.24), removed 2024-05-26 (v2.0)

Changed to disable to conform with all other pipes.


[Before](https://goreleaser.com/deprecations/#before_7)
[After](https://goreleaser.com/deprecations/#after_7)

changelog:
  disable: true
```